### PR TITLE
Fix upper_bound usage when value exceeds vector

### DIFF
--- a/lower_bound/lower_bound/lower_bound.cpp
+++ b/lower_bound/lower_bound/lower_bound.cpp
@@ -17,10 +17,10 @@ int main()
     vector<int> v;
     for (int i = 0; i < 20; ++i) v.push_back(dist(gen));
 
-    int loverBound = 65;
+    int lowerBound = 65;
     sort(v.begin(), v.end());
 
-    auto it = lower_bound(v.begin(), v.end(), loverBound);
+    auto it = lower_bound(v.begin(), v.end(), lowerBound);
 
 
     if (it != v.end()) {
@@ -39,9 +39,12 @@ int main()
     puts("");
 
 
-    it = upper_bound(v.begin(), v.end(), loverBound);
+    it = upper_bound(v.begin(), v.end(), lowerBound);
     puts("\n");
-    cout << "upper bound " << *it << " and pos in vec: " << (it - v.begin()) + 1 << '\n';
+    if (it != v.end())
+        cout << "upper bound " << *it << " and pos in vec: " << (it - v.begin()) + 1 << '\n';
+    else
+        cout << "upper bound not found" << '\n';
 
     while (it > v.begin()) cout << *(--it)<< ' ';
 


### PR DESCRIPTION
## Summary
- avoid dereferencing the iterator returned by `upper_bound` when the searched value is larger than any element
- store the search value in `lowerBound`

## Testing
- `g++ lower_bound/lower_bound/lower_bound.cpp -std=c++11 -o lb && ./lb | head -n 15`
- `g++ Sets/Sets/Sets.cpp -std=c++11 -o sets && ./sets`


------
https://chatgpt.com/codex/tasks/task_e_687995f85a688333ad5235cc97e636a2